### PR TITLE
Fix parsing python requirements.txt

### DIFF
--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -158,7 +158,7 @@ pub fn parse_requirements_txt(src: &Path) -> Option<PythonDependencies> {
         get_python_dependencies(
             BufReader::new(file)
                 .lines()
-                .filter_map(|line| Some(line.ok_warn()?.to_lowercase().to_kebab_case())),
+                .filter_map(|line| line.ok_warn()),
         )
     })
 }


### PR DESCRIPTION
get_python_dependencies expects raw lines, normalizing messes up the pep 508 parsing