### PR TITLE
CI fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 
 updates:
-  - package-ecosystem: "cargo"
+  - package-ecosystem: "cargo" # group cargo updates
     directory: "/"
     schedule:
       interval: "daily"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ queue_rules:
       - check-success=check (macos-latest)
       - check-success=check (ubuntu-latest)
       - check-success=buildbot/nix-build
-    batch_size: 5
+    batch_size: 5 # make batch wait time longer
     merge_method: rebase
 pull_request_rules:
   - name: merge using the merge queue

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   pname = "nix-init";
   version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
 
-  src = ./.;
+  src = ./.; # change this to minimise unrelated rebuilds
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes."cargo-0.82.0" = "sha256-1G14vLW3FhLxOWGxuHXcWgb+XXS1vOOyQYKVbrJWlmI=";


### PR DESCRIPTION
I've disabled CI on this repo for now as the combination of any change in the tree causing rebuilds, dependabot not grouping PRs and mergify creating even more PRs was choking our darwin builder.
