### PR TITLE
buildGoModule: drop -w from default ldflags

### DIFF
--- a/src/lang/go/goreleaser.rs
+++ b/src/lang/go/goreleaser.rs
@@ -23,7 +23,7 @@ struct Build {
 
 pub fn write_ldflags(out: &mut impl Write, src_dir: &Path) -> Result<()> {
     let (Some(raw), Some(re)) = (get_ldflags(src_dir), regex()) else {
-        writeln!(out, "  ldflags = [ \"-s\" \"-w\" ];\n")?;
+        writeln!(out, "  ldflags = [ \"-s\" ];\n")?;
         return Ok(());
     };
 


### PR DESCRIPTION
-w is implied by -s, so we can drop it here.