### PR TITLE
fix: remove unneeded ldflags

### DIFF
--- a/src/lang/go/goreleaser.rs
+++ b/src/lang/go/goreleaser.rs
@@ -23,7 +23,6 @@ struct Build {
 
 pub fn write_ldflags(out: &mut impl Write, src_dir: &Path) -> Result<()> {
     let (Some(raw), Some(re)) = (get_ldflags(src_dir), regex()) else {
-        writeln!(out, "  ldflags = [ \"-s\" \"-w\" ];\n")?;
         return Ok(());
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ async fn run() -> Result<()> {
             let version = match revisions.versions.remove(&rev) {
                 Some(version) => Some(version),
                 None => fetcher.get_version(&cl, &rev).await,
-            } ;
+            };
             let version = match version {
                 Some(Version::Latest | Version::Tag) => get_version_number(&rev).into(),
                 Some(Version::Pypi {


### PR DESCRIPTION
this was discussed/raised in https://discourse.nixos.org/t/why-do-so-many-go-packages-use-s-w-in-their-ldflags-it-breaks-dontfixup-dontstrip/36843/8

Testes manually that it generates a working derivation for a go project with no ldflags, and no longer adds `-s -w`