### PR TITLE
fetchCrate: fix api calls

### DIFF
--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -88,7 +88,7 @@ impl Fetcher {
     pub async fn create_client(&self, mut tokens: AccessTokens) -> Result<Client> {
         match self {
             Fetcher::FetchCrate { .. } => Client::builder()
-                .user_agent("Mozilla/5.0")
+                .user_agent("https://github.com/nix-community/nix-init")
                 .build()
                 .map_err(Into::into),
 


### PR DESCRIPTION
the original user agent stopped working at some point, switching to something more descriptive as required by crates.io's data access policy