### PR TITLE
toml: add std and serde features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5058,9 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.10+spec-1.1.0"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
  "indexmap 2.12.1",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ spdx = "0.13.3"
 tar = "0.4.44"
 tempfile = "3.24.0"
 time = { version = "0.3.44", features = ["parsing", "serde"] }
-toml = { version = "0.9.10", default-features = false, features = ["parse"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 url = "2.5.7"
@@ -74,6 +73,11 @@ features = ["derive", "with-fuzzy"]
 [dependencies.tokio]
 version = "1.48.0"
 features = ["macros", "process", "rt-multi-thread"]
+
+[dependencies.toml]
+version = "0.9.11"
+default-features = false
+features = ["parse", "serde", "std"]
 
 [build-dependencies]
 clap = { version = "4.5.53", features = ["derive"] }


### PR DESCRIPTION
When we added this dependency, the default features were only parse and display. Now that std and serde are features, we want to explicitly depend on it in case cargo stops depending on these features.