### PR TITLE
improve license detection

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -1,4 +1,6 @@
-use askalono::Store;
+use std::{collections::BTreeMap, ffi::OsStr, fmt::Display, fs::read_to_string, path::Path};
+
+use askalono::{ScanStrategy, Store, TextData};
 use once_cell::sync::Lazy;
 use spdx::{Expression, ParseMode};
 use tracing::{debug, warn};
@@ -24,6 +26,43 @@ pub fn parse_spdx_expression(license: &str, source: &'static str) -> Vec<&'stati
                 })
                 .collect()
         })
+}
+
+pub fn load_license(
+    licenses: &mut BTreeMap<&'static str, f32>,
+    relative_path: impl Display,
+    strategy: &ScanStrategy,
+    path: &Path,
+) {
+    if let Some((license, score)) = find_license(strategy, path) {
+        debug!("license found in {relative_path}: {license}");
+        licenses
+            .entry(license)
+            .and_modify(|max_score| *max_score = max_score.max(score))
+            .or_insert(score);
+    }
+}
+
+fn find_license(strategy: &ScanStrategy, path: &Path) -> Option<(&'static str, f32)> {
+    let text = read_to_string(path).ok_inspect(|e| warn!("{e}"))?;
+
+    let res = strategy
+        .scan(&TextData::from(text))
+        .ok_inspect(|e| warn!("{e}"))?;
+
+    let name = res.license?.name;
+
+    if let Some(prefix) = name.strip_suffix("-only")
+        && path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .is_some_and(|name| name.contains("-or-later"))
+        && let Some(license) = get_nix_license(&format!("{prefix}-or-later"))
+    {
+        Some((license, res.score))
+    } else {
+        Some((get_nix_license(name)?, res.score))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- look into root level directories named licen{s,c}e* and copying*
- add some heuristics to prefer the -or-later licenses when the file names contain -or-later
- not mentioned in the commit message since i forgot: update the score if the license already had a lower score, seems like an oversight when i initially implemented the logic

closes #650