### PR TITLE
readme: fix ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![release](https://img.shields.io/github/v/release/nix-community/nix-init?logo=github&style=flat-square)](https://github.com/nix-community/nix-init/releases)
 [![version](https://img.shields.io/crates/v/nix-init?logo=rust&style=flat-square)](https://crates.io/crates/nix-init)
 [![license](https://img.shields.io/badge/license-MPL--2.0-blue?style=flat-square)](https://www.mozilla.org/en-US/MPL/2.0)
-[![ci](https://img.shields.io/github/actions/workflow/status/nix-community/nix-init/ci.yml?label=ci&logo=github-actions&style=flat-square)](https://github.com/nix-community/nix-init/actions?query=workflow:ci)
+[![ci](https://img.shields.io/github/checks-status/nix-community/nix-init/main?style=flat-square)](https://buildbot.nix-community.org/#/builders/2728)
 
 Generate Nix packages from URLs
 


### PR DESCRIPTION
the old one stopped working because github actions was replaced with buildbot in #681