### PR TITLE
feat: use release page as changelog fallback

### DIFF
--- a/src/fetcher/crates_io.rs
+++ b/src/fetcher/crates_io.rs
@@ -61,6 +61,7 @@ impl Fetcher for FetchCrate {
                 homepage,
                 license: Vec::new(),
                 python_dependencies: Default::default(),
+                releases_page: None,
                 revisions: Revisions {
                     latest: "".into(),
                     completions,
@@ -131,6 +132,7 @@ impl Fetcher for FetchCrate {
             }),
             homepage,
             python_dependencies: Default::default(),
+            releases_page: None,
             revisions: Revisions {
                 latest,
                 completions,

--- a/src/fetcher/gitea.rs
+++ b/src/fetcher/gitea.rs
@@ -24,6 +24,8 @@ struct Repo {
 #[derive(Deserialize)]
 struct Release {
     tag_name: String,
+    #[serde(default)]
+    body: String,
 }
 
 #[derive(Deserialize)]
@@ -73,7 +75,7 @@ impl Fetcher for FetchFromGitea {
             async {
                 json::<[Release; 1]>(cl, format!("{root}/releases?limit=1"))
                     .await
-                    .map(|[release]| release.tag_name)
+                    .map(|[release]| release)
             },
             json::<Vec<_>>(cl, format!("{root}/tags?page=1&limit=12")),
             json::<Vec<_>>(cl, format!("{root}/commits?limit=12&stat=false")),
@@ -82,13 +84,24 @@ impl Fetcher for FetchFromGitea {
         let mut completions = vec![];
         let mut versions = FxHashMap::default();
 
-        let mut latest = if let Some(latest) = &latest_release {
-            versions.insert(latest.clone(), Version::Latest);
-            completions.push(Pair {
-                display: format!("{latest} (latest release)"),
-                replacement: latest.clone(),
+        let releases_page = latest_release
+            .as_ref()
+            .filter(|r| r.body.trim().len() >= 20)
+            .map(|_| {
+                format!(
+                    "https://{}/{}/{}/releases/tag/${{finalAttrs.src.tag}}",
+                    self.domain, self.owner, self.repo,
+                )
             });
-            latest.clone()
+
+        let mut latest = if let Some(latest) = &latest_release {
+            let tag = &latest.tag_name;
+            versions.insert(tag.clone(), Version::Latest);
+            completions.push(Pair {
+                display: format!("{tag} (latest release)"),
+                replacement: tag.clone(),
+            });
+            tag.clone()
         } else {
             "".into()
         };
@@ -101,7 +114,7 @@ impl Fetcher for FetchFromGitea {
             }
 
             for Tag { name } in tags {
-                if matches!(&latest_release, Some(tag) if tag == &name) {
+                if matches!(&latest_release, Some(r) if r.tag_name == name) {
                     continue;
                 }
                 completions.push(Pair {
@@ -162,6 +175,7 @@ impl Fetcher for FetchFromGitea {
             homepage,
             license: Vec::new(),
             python_dependencies: Default::default(),
+            releases_page,
             revisions: Revisions {
                 latest,
                 completions,

--- a/src/fetcher/github.rs
+++ b/src/fetcher/github.rs
@@ -30,6 +30,8 @@ struct Repo {
 #[derive(Deserialize)]
 struct LatestRelease {
     tag_name: String,
+    #[serde(default)]
+    body: String,
 }
 
 #[derive(Deserialize)]
@@ -78,11 +80,7 @@ impl Fetcher for FetchFromGitHub {
                     .await
                     .map_or_else(String::new, |repo: Repo| repo.description)
             },
-            async {
-                json(cl, format!("{root}/releases/latest"))
-                    .await
-                    .map(|latest_release: LatestRelease| latest_release.tag_name)
-            },
+            json::<LatestRelease>(cl, format!("{root}/releases/latest")),
             json::<Vec<_>>(cl, format!("{root}/git/matching-refs/tags/")),
             json::<Vec<_>>(cl, format!("{root}/commits?per_page=12")),
         );
@@ -90,13 +88,24 @@ impl Fetcher for FetchFromGitHub {
         let mut completions = vec![];
         let mut versions = FxHashMap::default();
 
-        let mut latest = if let Some(latest) = &latest_release {
-            versions.insert(latest.clone(), Version::Latest);
-            completions.push(Pair {
-                display: format!("{latest} (latest release)"),
-                replacement: latest.clone(),
+        let releases_page = latest_release
+            .as_ref()
+            .filter(|r| r.body.trim().len() >= 20)
+            .map(|_| {
+                format!(
+                    "https://{}/{}/{}/releases/tag/${{finalAttrs.src.tag}}",
+                    self.github_base, self.owner, self.repo,
+                )
             });
-            latest.clone()
+
+        let mut latest = if let Some(latest) = &latest_release {
+            let tag = &latest.tag_name;
+            versions.insert(tag.clone(), Version::Latest);
+            completions.push(Pair {
+                display: format!("{tag} (latest release)"),
+                replacement: tag.clone(),
+            });
+            tag.clone()
         } else {
             "".into()
         };
@@ -127,7 +136,7 @@ impl Fetcher for FetchFromGitHub {
             }
 
             for tag in tags {
-                if matches!(&latest_release, Some(latest) if latest == &tag) {
+                if matches!(&latest_release, Some(r) if r.tag_name == tag) {
                     continue;
                 }
                 completions.push(Pair {
@@ -188,6 +197,7 @@ impl Fetcher for FetchFromGitHub {
             homepage,
             license: Vec::new(),
             python_dependencies: Default::default(),
+            releases_page,
             revisions: Revisions {
                 latest,
                 completions,

--- a/src/fetcher/gitlab.rs
+++ b/src/fetcher/gitlab.rs
@@ -30,6 +30,8 @@ struct Repo {
 #[derive(Deserialize)]
 struct LatestRelease {
     tag_name: String,
+    #[serde(default)]
+    description: String,
 }
 
 #[derive(Deserialize)]
@@ -63,11 +65,7 @@ impl Fetcher for FetchFromGitLab {
                     .await
                     .map_or_else(String::new, |repo: Repo| repo.description)
             },
-            async {
-                json(cl, format!("{root}/releases/permalink/latest"))
-                    .await
-                    .map(|latest_release: LatestRelease| latest_release.tag_name)
-            },
+            json::<LatestRelease>(cl, format!("{root}/releases/permalink/latest")),
             json::<Vec<_>>(cl, format!("{root}/repository/tags?per_page=12")),
             json::<Vec<_>>(cl, format!("{root}/repository/commits?per_page=12")),
         );
@@ -75,13 +73,30 @@ impl Fetcher for FetchFromGitLab {
         let mut completions = vec![];
         let mut versions = FxHashMap::default();
 
-        let mut latest = if let Some(latest) = &latest_release {
-            versions.insert(latest.clone(), Version::Latest);
-            completions.push(Pair {
-                display: format!("{latest} (latest release)"),
-                replacement: latest.clone(),
+        let releases_page = latest_release
+            .as_ref()
+            .filter(|r| r.description.trim().len() >= 20)
+            .map(|_| {
+                let mut page = format!("https://{}/", self.domain);
+                if let Some(group) = &self.group {
+                    let _ = write!(page, "{group}/");
+                }
+                let _ = write!(
+                    page,
+                    "{}/{}/-/releases/${{finalAttrs.src.tag}}",
+                    self.owner, self.repo,
+                );
+                page
             });
-            latest.clone()
+
+        let mut latest = if let Some(latest) = &latest_release {
+            let tag = &latest.tag_name;
+            versions.insert(tag.clone(), Version::Latest);
+            completions.push(Pair {
+                display: format!("{tag} (latest release)"),
+                replacement: tag.clone(),
+            });
+            tag.clone()
         } else {
             "".into()
         };
@@ -94,7 +109,7 @@ impl Fetcher for FetchFromGitLab {
             }
 
             for Tag { name } in tags {
-                if matches!(&latest_release, Some(tag) if tag == &name) {
+                if matches!(&latest_release, Some(r) if r.tag_name == name) {
                     continue;
                 }
                 completions.push(Pair {
@@ -167,6 +182,7 @@ impl Fetcher for FetchFromGitLab {
             homepage,
             license: Vec::new(),
             python_dependencies: Default::default(),
+            releases_page,
             revisions: Revisions {
                 latest,
                 completions,

--- a/src/fetcher/mod.rs
+++ b/src/fetcher/mod.rs
@@ -76,6 +76,7 @@ pub struct PackageInfo {
     pub homepage: String,
     pub license: Vec<&'static str>,
     pub python_dependencies: PythonDependencies,
+    pub releases_page: Option<String>,
     pub revisions: Revisions,
 }
 

--- a/src/fetcher/pypi.rs
+++ b/src/fetcher/pypi.rs
@@ -66,6 +66,7 @@ impl Fetcher for FetchPypi {
                 homepage,
                 license: Vec::new(),
                 python_dependencies: Default::default(),
+                releases_page: None,
                 revisions: Revisions {
                     latest: "".into(),
                     completions,
@@ -127,6 +128,7 @@ impl Fetcher for FetchPypi {
                 .license
                 .map_or_else(Vec::new, |license| parse_spdx_expression(&license, "pypi")),
             python_dependencies: get_python_dependencies(project.info.requires_dist),
+            releases_page: None,
             revisions: Revisions {
                 latest: completions
                     .first()

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ async fn run() -> Result<()> {
     let mut cmd = Command::new(NURL);
     let mut licenses = BTreeMap::new();
     let mut pypi_format = PypiFormat::TarGz;
-    let (pname, rev, version, desc, prefix, mut python_deps) =
+    let (pname, rev, version, desc, prefix, releases_page, mut python_deps) =
         if let MaybeFetcher::Known(fetcher) = &mut fetcher {
             let cl = fetcher.create_client(cfg.access_tokens).await?;
 
@@ -134,6 +134,7 @@ async fn run() -> Result<()> {
                 file_url_prefix,
                 homepage,
                 license,
+                mut releases_page,
                 python_dependencies,
                 mut revisions,
             } = fetcher.get_package_info(&cl).await;
@@ -168,6 +169,9 @@ async fn run() -> Result<()> {
                     Some(version) => Some(version),
                     None => fetcher.get_version(&cl, &rev).await,
                 };
+                if !matches!(version, Some(Version::Latest | Version::Tag)) {
+                    releases_page = None;
+                }
                 let version = match version {
                     Some(Version::Latest | Version::Tag) => get_version_number(&rev).into(),
                     Some(Version::Pypi {
@@ -195,6 +199,7 @@ async fn run() -> Result<()> {
                 version,
                 description,
                 file_url_prefix,
+                releases_page,
                 python_dependencies,
             )
         } else {
@@ -217,7 +222,15 @@ async fn run() -> Result<()> {
                 None => frontend.version(get_version(&rev))?,
             };
 
-            (pname, rev, version, "".into(), None, Default::default())
+            (
+                pname,
+                rev,
+                version,
+                "".into(),
+                None,
+                None,
+                Default::default(),
+            )
         };
 
     let pname = match opts.pname {
@@ -960,6 +973,7 @@ async fn run() -> Result<()> {
             homepage = {url:?};
     "}?;
 
+    let mut found_changelog = false;
     if let Some(prefix) = prefix
         && let Some(walk) = read_dir(&src_dir).ok_inspect(|e| warn!("{e}"))
     {
@@ -982,9 +996,13 @@ async fn run() -> Result<()> {
                 expand!([@b"changelog", ..] | [@b"changes", ..] | [@b"news"] | [@b"releases", ..]),
             ) {
                 writeln!(out, r#"    changelog = "{prefix}{name}";"#)?;
+                found_changelog = true;
                 break;
             }
         }
+    }
+    if !found_changelog && let Some(releases_page) = releases_page {
+        writeln!(out, r#"    changelog = "{releases_page}";"#)?;
     }
 
     if let (Some(store), Some(entries)) = (

--- a/tests/cmd/drv-no-cc.out/default.nix
+++ b/tests/cmd/drv-no-cc.out/default.nix
@@ -18,6 +18,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "[..]";
     homepage = "https://github.com/z-shell/zi";
+    changelog = "https://github.com/z-shell/zi/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ alice ];
     mainProgram = "zi";

--- a/tests/cmd/drv-rust.out/default.nix
+++ b/tests/cmd/drv-rust.out/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "[..]";
     homepage = "https://github.com/ErikReider/SwayOSD";
+    changelog = "https://github.com/ErikReider/SwayOSD/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ alice ];
     mainProgram = "sway-osd";

--- a/tests/cmd/drv.out/default.nix
+++ b/tests/cmd/drv.out/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "[..]";
     homepage = "https://github.com/containers/bubblewrap";
+    changelog = "https://github.com/containers/bubblewrap/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl2Only;
     maintainers = with lib.maintainers; [ alice ];
     mainProgram = "bubblewrap";


### PR DESCRIPTION
## Summary

- When no changelog file is found in the source tree, falls back to the forge's releases page URL as the `changelog` meta attribute
- Only uses the releases page when the latest release has a meaningful body (>= 20 characters after trimming), filtering out auto-generated or empty release notes
- Supports GitHub, GitLab, and Gitea forges

closes #641.

disclaimer i used a coding agent in the creation of this patch.
