### PR TITLE
feat: add `passthru.updateScript` where nurl fetchers are known

### DIFF
--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -24,6 +24,8 @@ pub struct Inputs {
     pub x86_64_linux: BTreeSet<String>,
 }
 
+// "all" here refers to all systems
+// does not write out python inputs or nix-update-script
 pub fn write_all_lambda_inputs(
     out: &mut impl Write,
     inputs: &AllInputs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -556,7 +556,7 @@ async fn run() -> Result<()> {
         }
     }
 
-    let nix_update_supported = matches!(fetcher, MaybeFetcher::Known(_));
+    let nix_update_script = matches!(fetcher, MaybeFetcher::Known(_));
     match fetcher {
         MaybeFetcher::Known(fetcher) => {
             writeln!(out, "  {fetcher},")?;
@@ -564,10 +564,6 @@ async fn run() -> Result<()> {
         MaybeFetcher::Unknown { fetcher } => {
             writeln!(out, "  {fetcher},")?;
         }
-    }
-
-    if nix_update_supported {
-        writeln!(out, "  nix-update-script,")?;
     }
 
     let mut python_import = None;
@@ -593,6 +589,10 @@ async fn run() -> Result<()> {
             };
 
             let res = write_all_lambda_inputs(&mut out, &inputs, &mut BTreeSet::new())?;
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
+
             writedoc! {out, r#"
                 }}:
 
@@ -679,6 +679,9 @@ async fn run() -> Result<()> {
                     write_lambda_input(&mut out, &mut written, &name.to_kebab_case())?;
                 }
             }
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
 
             writedoc! {out, r#"
                 }}:
@@ -732,8 +735,13 @@ async fn run() -> Result<()> {
                 &nixpkgs,
             )
             .await;
+
             let res =
                 write_all_lambda_inputs(&mut out, &inputs, &mut ["rustPlatform".into()].into())?;
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
+
             writedoc! {out, r#"
                 }}:
 
@@ -767,6 +775,10 @@ async fn run() -> Result<()> {
 
             let res =
                 write_all_lambda_inputs(&mut out, &inputs, &mut ["rustPlatform".into()].into())?;
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
+
             writedoc! {out, r#"
                 }}:
 
@@ -784,6 +796,10 @@ async fn run() -> Result<()> {
 
         Builder::MkDerivation { rust: None } => {
             let res = write_all_lambda_inputs(&mut out, &inputs, &mut ["stdenv".into()].into())?;
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
+
             writedoc! { out, r#"
                 }}:
 
@@ -810,7 +826,12 @@ async fn run() -> Result<()> {
                 &nixpkgs,
             )
             .await;
+
             let res = write_all_lambda_inputs(&mut out, &inputs, &mut ["stdenv".into()].into())?;
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
+
             writedoc! {out, r#"
                 }}:
 
@@ -846,6 +867,10 @@ async fn run() -> Result<()> {
             };
 
             let res = write_all_lambda_inputs(&mut out, &inputs, &mut ["stdenv".into()].into())?;
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
+
             writedoc! {out, r#"
                 }}:
 
@@ -864,6 +889,10 @@ async fn run() -> Result<()> {
         Builder::MkDerivationNoCC => {
             let res =
                 write_all_lambda_inputs(&mut out, &inputs, &mut ["stdenvNoCC".into()].into())?;
+            if nix_update_script {
+                writeln!(out, "  nix-update-script,")?;
+            }
+
             writedoc! { out, r#"
                 }}:
 
@@ -956,7 +985,7 @@ async fn run() -> Result<()> {
         writeln!(out, "  }};\n")?;
     }
 
-    if nix_update_supported {
+    if nix_update_script {
         writeln!(out, "  passthru.updateScript = nix-update-script {{ }};\n")?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -556,6 +556,7 @@ async fn run() -> Result<()> {
         }
     }
 
+    let nix_update_supported = matches!(fetcher, MaybeFetcher::Known(_));
     match fetcher {
         MaybeFetcher::Known(fetcher) => {
             writeln!(out, "  {fetcher},")?;
@@ -563,6 +564,10 @@ async fn run() -> Result<()> {
         MaybeFetcher::Unknown { fetcher } => {
             writeln!(out, "  {fetcher},")?;
         }
+    }
+
+    if nix_update_supported {
+        writeln!(out, "  nix-update-script,")?;
     }
 
     let mut python_import = None;
@@ -949,6 +954,10 @@ async fn run() -> Result<()> {
             writeln!(out, "    {k} = {v};")?;
         }
         writeln!(out, "  }};\n")?;
+    }
+
+    if nix_update_supported {
+        writeln!(out, "  passthru.updateScript = nix-update-script {{ }};\n")?;
     }
 
     let mut desc = desc.trim_matches(|c: char| !c.is_alphanumeric()).to_owned();

--- a/tests/cmd/drv-no-cc.out/default.nix
+++ b/tests/cmd/drv-no-cc.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -14,6 +15,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-nuw/riQaAdk0fYUpm3z978YGPDJnzc66DnOj774tPu0=";
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/drv-rust.out/default.nix
+++ b/tests/cmd/drv-rust.out/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  nix-update-script,
   cargo,
   meson,
   ninja,
@@ -21,6 +20,7 @@
   libpulseaudio,
   pango,
   udev,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/tests/cmd/drv-rust.out/default.nix
+++ b/tests/cmd/drv-rust.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
   cargo,
   meson,
   ninja,
@@ -61,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     pango
     udev
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/drv-sourcehut.out/default.nix
+++ b/tests/cmd/drv-sourcehut.out/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scdoc";
+  version = "1.11.3";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "scdoc";
+    tag = finalAttrs.version;
+    hash = "sha256-MbLDhLn/JY6OcdOz9/mIPAQRp5TZ6IKuQ/FQ/R3wjGc=";
+  };
+
+  meta = {
+    description = "[..]";
+    homepage = "https://git.sr.ht/~sircmpwn/scdoc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ alice ];
+    mainProgram = "scdoc";
+    platforms = lib.platforms.all;
+  };
+})

--- a/tests/cmd/drv-sourcehut.toml
+++ b/tests/cmd/drv-sourcehut.toml
@@ -1,0 +1,5 @@
+args = [
+  "--headless",
+  "--url=https://git.sr.ht/~sircmpwn/scdoc",
+  "--rev=1.11.3",
+]

--- a/tests/cmd/drv-sourcehut.toml
+++ b/tests/cmd/drv-sourcehut.toml
@@ -1,5 +1,1 @@
-args = [
-  "--headless",
-  "--url=https://git.sr.ht/~sircmpwn/scdoc",
-  "--rev=1.11.3",
-]
+args = ["--headless", "--url=https://git.sr.ht/~sircmpwn/scdoc", "--rev=1.11.3"]

--- a/tests/cmd/drv.out/default.nix
+++ b/tests/cmd/drv.out/default.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  nix-update-script,
   meson,
   ninja,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/tests/cmd/drv.out/default.nix
+++ b/tests/cmd/drv.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
   meson,
   ninja,
 }:
@@ -21,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/go.out/default.nix
+++ b/tests/cmd/go.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
@@ -23,6 +24,8 @@ buildGoModule (finalAttrs: {
     "-X=main.version=${finalAttrs.version}"
     "-X=main.revision=${finalAttrs.src.rev}"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/python-app.out/default.nix
+++ b/tests/cmd/python-app.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   python3,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -52,6 +53,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pythonImportsCheck = [
     "black"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/python-lib.out/default.nix
+++ b/tests/cmd/python-lib.out/default.nix
@@ -2,10 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  nix-update-script,
   flit-core,
   markupsafe,
   babel,
+  nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {

--- a/tests/cmd/python-lib.out/default.nix
+++ b/tests/cmd/python-lib.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
   flit-core,
   markupsafe,
   babel,
@@ -36,6 +37,8 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [
     "jinja2"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/python-rust.out/default.nix
+++ b/tests/cmd/python-rust.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
   cargo,
   cffi,
   pkg-config,
@@ -112,6 +113,8 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [
     "cryptography"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/python-rust.out/default.nix
+++ b/tests/cmd/python-rust.out/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  nix-update-script,
   cargo,
   cffi,
   pkg-config,
@@ -32,6 +31,7 @@
   pytest-cov,
   pytest-xdist,
   pytest-randomly,
+  nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {

--- a/tests/cmd/rust.out/default.nix
+++ b/tests/cmd/rust.out/default.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  nix-update-script,
   curl,
   pkg-config,
   libgit2,
@@ -10,6 +9,7 @@
   sqlite,
   zlib,
   zstd,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {

--- a/tests/cmd/rust.out/default.nix
+++ b/tests/cmd/rust.out/default.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
   curl,
   pkg-config,
   libgit2,
@@ -44,6 +45,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     OPENSSL_NO_VENDOR = true;
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";


### PR DESCRIPTION
Adds `passthru.updateScript = nix-update-script { };` where nurl fetchers are known.

closes #642.

dsisclaimer i used a coding agent in the creation of this patch.
