### PR TITLE
fix: only add nix-update-script for non-GitHub fetchers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -584,7 +584,7 @@ async fn run() -> Result<()> {
         }
     }
 
-    let nix_update_script = matches!(fetcher, MaybeFetcher::Known(_));
+    let nix_update_script = matches!(fetcher, MaybeFetcher::Known(ref f) if !matches!(f, FetcherDispatch::FetchFromGitHub(_)));
     match fetcher {
         MaybeFetcher::Known(fetcher) => {
             writeln!(out, "  {fetcher},")?;

--- a/tests/cmd/drv-gitlab.out/default.nix
+++ b/tests/cmd/drv-gitlab.out/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "beast";
+  version = "1.1.2";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    owner = "emilua";
+    repo = "beast";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MASaZvhIVKmeBUcn/NjlBZ+xh+2RgwHBH2o08lklGa0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "[..]";
+    homepage = "https://gitlab.com/emilua/beast";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [ alice ];
+    mainProgram = "beast";
+    platforms = lib.platforms.all;
+  };
+})

--- a/tests/cmd/drv-gitlab.toml
+++ b/tests/cmd/drv-gitlab.toml
@@ -1,0 +1,1 @@
+args = ["--headless", "--url=https://gitlab.com/emilua/beast", "--rev=v1.1.2"]

--- a/tests/cmd/drv-no-cc.out/default.nix
+++ b/tests/cmd/drv-no-cc.out/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -17,8 +16,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-nuw/riQaAdk0fYUpm3z978YGPDJnzc66DnOj774tPu0=";
   };
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/drv-rust.out/default.nix
+++ b/tests/cmd/drv-rust.out/default.nix
@@ -20,7 +20,6 @@
   libpulseaudio,
   pango,
   udev,
-  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -64,8 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     pango
     udev
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/drv.out/default.nix
+++ b/tests/cmd/drv.out/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   meson,
   ninja,
-  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,8 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/go.out/default.nix
+++ b/tests/cmd/go.out/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
@@ -25,8 +24,6 @@ buildGoModule (finalAttrs: {
     "-X=main.version=${finalAttrs.version}"
     "-X=main.revision=${finalAttrs.src.rev}"
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/python-app.out/default.nix
+++ b/tests/cmd/python-app.out/default.nix
@@ -2,7 +2,6 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -54,8 +53,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pythonImportsCheck = [
     "black"
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/python-lib.out/default.nix
+++ b/tests/cmd/python-lib.out/default.nix
@@ -5,7 +5,6 @@
   flit-core,
   markupsafe,
   babel,
-  nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -38,8 +37,6 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [
     "jinja2"
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/python-rust.out/default.nix
+++ b/tests/cmd/python-rust.out/default.nix
@@ -31,7 +31,6 @@
   pytest-cov,
   pytest-xdist,
   pytest-randomly,
-  nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -114,8 +113,6 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [
     "cryptography"
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";

--- a/tests/cmd/rust.out/default.nix
+++ b/tests/cmd/rust.out/default.nix
@@ -9,7 +9,6 @@
   sqlite,
   zlib,
   zstd,
-  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -46,8 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     OPENSSL_NO_VENDOR = true;
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "[..]";


### PR DESCRIPTION
PR #768 added `passthru.updateScript = nix-update-script { };` for all packages where the fetcher is known. However, as clarified in [NixOS/nixpkgs#502056](https://github.com/NixOS/nixpkgs/pull/502056), this is redundant for GitHub-hosted packages: `nixpkgs-update` (r-ryantm) already discovers and updates those automatically via native GitHub releases discovery, without needing an explicit `updateScript`.

`nix-update-script` is genuinely useful for forges like GitLab and Gitea where Repology coverage is weaker and `nix-update` finds new versions more reliably.

Restrict the condition to known fetchers other than `fetchFromGitHub`, remove `nix-update-script` from the GitHub-based test fixtures, and add a new `fetchFromGitLab` test (`gitlab.com/emilua/beast`) that exercises the case where `nix-update-script` is correctly emitted.
