### PR TITLE
feat(flake): add a new devshell that includes full dev tools

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+use flake .#full

--- a/flake.nix
+++ b/flake.nix
@@ -39,21 +39,30 @@
           ...
         }:
         {
-          devShells.default = pkgs.mkShell {
-            packages = [
-              pkgs.nurl
-            ];
+          devShells = {
+            default = pkgs.mkShell {
+              packages = [
+                pkgs.nurl
+              ];
 
-            env = {
-              NIX_INIT_LOG = "nix_init=trace";
-              RUST_BACKTRACE = true;
+              env = {
+                NIX_INIT_LOG = "nix_init=trace";
+                RUST_BACKTRACE = true;
+              };
+
+              shellHook = ''
+                mkdir -p data
+                ln -sf ${config.packages.get-nix-license} data/get_nix_license.rs
+                ln -sf ${config.packages.license-store-cache} data/license-store-cache.zstd
+              '';
             };
-
-            shellHook = ''
-              mkdir -p data
-              ln -sf ${config.packages.get-nix-license} data/get_nix_license.rs
-              ln -sf ${config.packages.license-store-cache} data/license-store-cache.zstd
-            '';
+            full = pkgs.mkShell {
+              imports = [ config.devShells.default ];
+              buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.curl ];
+              packages = [
+                inputs'.fenix.packages.stable.defaultToolchain
+              ];
+            };
           };
 
           packages = {


### PR DESCRIPTION
There is annoyance that I commonly run into when developing nix-init and maybe pottentially others, no rust tooling in the devshell AUGH. This pr changes that FINALLY! by adding the fenix latest toolchain to devshell.

/CC @figsoda for review.

> Disclaimer: This is sponsered work at DigitalBrewStudios.
