### PR TITLE
fix: rust: cargoLock: clear query and fragment from package urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Add support for `buildNpmPackage`
 
+### Fixes
+
+- Rust: cargoLock: clear query and fragment from package urls
+  ([#865](https://github.com/nix-community/nix-init/pull/865))
+
 ## v0.3.6 - 2026-05-15
 
 ### Fixes

--- a/src/lang/rust/mod.rs
+++ b/src/lang/rust/mod.rs
@@ -147,8 +147,13 @@ pub async fn write_cargo_lock(
         let hashes: BTreeMap<_, _> = revs
             .into_par_iter()
             .filter_map(|(rev, pkg)| {
+                let source_id = pkg.source_id();
+                let mut url = source_id.url().clone();
+                url.set_query(None);
+                url.set_fragment(None);
+
                 let hash = Command::new(NURL)
-                    .arg(pkg.source_id().as_url().to_string())
+                    .arg(url.to_string())
                     .arg(rev)
                     .arg("-Hf")
                     .arg("fetchgit")


### PR DESCRIPTION
It could otherwise result in flake references like `git+https://github.com/user/repo?rev=short#long?allRefs=1&rev=long&submodules=1`, which is illegal and would fail.

The specific issue I ran into is:
```
nix-init . --url https://github.com/2e3s/aw-watcher-media-player
Enter tag or revision (defaults to v1.1.4)
❯ v1.1.4
Enter version
❯ 1.1.4
Enter pname
❯ aw-watcher-media-player
How should this package be built?
❯ 2 - buildRustPackage - cargoLock
2026-08-29T20:46:13.427492Z ERROR nix_init::lang::rust: src/lang/rust/mod.rs:155: command exited with exit status: 1
stdout:

stderr:
$ nix flake prefetch --extra-experimental-features 'nix-command flakes' --json git+https://github.com/ActivityWatch/aw-server-rust?rev=448312d#448312d410980d4a92a0fb4d4bb3fa3494cf6c89?allRefs=1&rev=448312d410980d4a92a0fb4d4bb3fa3494cf6c89&submodules=1
error: unexpected fragment '448312d410980d4a92a0fb4d4bb3fa3494cf6c89?allRefs=1&rev=448312d410980d4a92a0fb4d4bb3fa3494cf6c89&submodules=1' in flake reference 'git+https://github.com/ActivityWatch/aw-server-rust?rev=448312d#448312d410980d4a92a0fb4d4bb3fa3494cf6c89?allRefs=1&rev=448312d410980d4a92a0fb4d4bb3fa3494cf6c89&submodules=1'
Error: command exited with exit status: 1

Location:
    src/prefetch.rs:22:13
```
This now works with these changes (at least on my machine™ :) )